### PR TITLE
Possible solution for providing ordered fields on JObject

### DIFF
--- a/jvm/src/main/scala/org/json4s/ast/InsertionOrderMap.scala
+++ b/jvm/src/main/scala/org/json4s/ast/InsertionOrderMap.scala
@@ -1,0 +1,37 @@
+package org.json4s.ast
+
+/**
+ * An immutable map that maintains insertion order.
+ *
+ * It has the following performance characteristics:
+ *
+ * - Lookup: eC
+ * - Add: eC, assuming the element isn't already in the map.
+ * - Update: L
+ * - Remove: L
+ *
+ * For some operations on this map, such as add, concatenate, remove, the insertion order of the new map will also be
+ * maintained. For other operations, specifically those defined by GenMap, GenIterable, GenTraversable, etc, such as
+ * map, filter, collect, the returned map will lose the insertion order.
+ */
+private class InsertionOrderMap[K, V] private (underlying: Map[K, V], values: Vector[(K, V)]) extends Map[K, V] {
+
+  def this(values: Vector[(K, V)] = Vector.empty) = this(values.toMap, values)
+
+  def +[B1 >: V](kv: (K, B1)) = {
+    if (contains(kv._1)) {
+      new InsertionOrderMap(underlying + kv, values.map {
+        case (key, _) if key == kv._1 => kv
+        case other => other
+      })
+    } else {
+      new InsertionOrderMap(underlying + kv, values :+ kv)
+    }
+  }
+
+  def get(key: K) = underlying.get(key)
+
+  def iterator = values.iterator
+
+  def -(key: K) = new InsertionOrderMap(underlying - key, values.filterNot(_._1 == key))
+}

--- a/jvm/src/main/scala/org/json4s/ast/JValue.scala
+++ b/jvm/src/main/scala/org/json4s/ast/JValue.scala
@@ -44,6 +44,25 @@ case object JFalse extends JBoolean {
   def get = false
 }
 
+object JObject {
+
+  /**
+   * Create a [[JObject]] whose fields maintain insertion iteration order.
+   *
+   * The map that backs this JObject will have the same iteration order as the passed in vector.
+   *
+   * Some operations on the map will maintain the iteration order, these include the methods defined by
+   * [[scala.collection.immutable.MapLike]], such as [[scala.collection.immutable.MapLike.+]] and
+   * [[scala.collection.immutable.MapLike.++]]. Other operations will lose the iteration order, particularly the
+   * methods defined by [[scala.collection.GenTraversable]], like [[scala.collection.GenTraversable.map]] and
+   * [[scala.collection.GenTraversable.filter]].
+   *
+   * The performance characteristics of the map are amortized constant time for lookups and adding keys that didn't
+   * previously exist, while updating values for existing keys and removing keys take linear time.
+   */
+  def ordered(value: Vector[(String,JValue)] = Vector.empty): JObject = JObject(new InsertionOrderMap(value))
+}
+
 case class JObject(value: Map[String,JValue] = Map.empty) extends JValue
 
 object JArray {


### PR DESCRIPTION
The idea of this solution is that ordered fields are opt in, and that the complexity of JObject is not impacted - JObject itself remains completely unchanged.

The drawbacks, in terms of performance and losing the ordering on certain operations, are documented.

For the use cases I envision (in Play), this should satisfy them.

Note, this solution does not at all address hash consistency - for that I think we should define a custom hash code method on `JObject` that hashes the map based on a sorted ordering of the keys, but that is beyond the scope of this PR.
